### PR TITLE
Create vmware_esxi_cve-2024-37085.yml

### DIFF
--- a/detections/endpoint/vmware_esxi_cve-2024-37085.yml
+++ b/detections/endpoint/vmware_esxi_cve-2024-37085.yml
@@ -1,0 +1,70 @@
+name: VMWare ESXi CVE-2024-37085
+id: e8c08f80-c382-4f24-8d95-1a8f4e358eba
+version: 1
+date: "2024-07-29"
+author: Brandon Sternfield, Optiv + ClearShark
+type: TTP
+status: experimental
+data_source:
+- Windows Event Log Security 4726
+- Windows Event Log Security 4731
+- Windows Event Log Security 4744
+- Windows Event Log Security 4749
+- Windows Event Log Security 4754
+- Windows Event Log Security 4759
+- Windows Event Log Security 4783
+- Windows Event Log Security 4790
+description: If someone creates a security group in AD called 'ESX Admins'
+and puts themselves in it, VMWare ESXi will let them authenticate as admins
+automatically giving them full access. This detection looks for the creation
+of this group to alert upon.
+search: '`wineventlog_security` PrivilegeList SidHistory
+SamAccountName TargetDomainName TargetUserName
+|  search EventCode IN (4727,4731,4744,4749,4754,4759,4783,4790)
+| eval object_category=case(
+EventCode=="4731", "Local Group (Security)",
+EventCode=="4744", "Local Group (Distribution)",
+EventCode=="4727", "Global Group (Security)",
+EventCode=="4749", "Global Group (Distribution)",
+EventCode=="4754", "Universal Group (Security)",
+EventCode=="4759", "Universal Group (Distribution)",
+EventCode=="4783", "Basic Application Group",
+EventCode=="4790", "LDAP Query Group")
+| search TargetUserName="ESX Admins"
+| eval _time = strptime(SystemTime, "'%Y-%m-%dT%H:%M:%S.%9Q%Z'")
+| table _time src_user object_category TargetUserName TargetSid dest result
+status
+| rename result AS change_type, TargetUserName AS object, TargetSid AS
+object_path | `vmware_esxi_cve-2024-37085_filter`'
+how_to_implement: To successfully implement this search you need to be ingesting Windows Security Events from a Domain Controller in regards to Active Directory modifications. In addition, confirm
+  the latest CIM App 4.20 or higher is installed and the latest TA''s are installed.
+known_false_positives: None
+references:
+- https://nvd.nist.gov/vuln/detail/CVE-2024-37085
+- https://www.rapid7.com/blog/post/2024/07/30/vmware-esxi-cve-2024-37085-targeted-in-ransomware-campaigns/%5C
+tags:
+  asset_type: Network
+  confidence: 100
+  cve:
+  - CVE-2024-37085
+  impact: 100
+  message: CVE-2024-37085 Exploitation Detected on $dest$ by $src_user$.
+  observable:
+  - name: src_user
+    type: User
+    role:
+    - Attacker
+  product:
+  - Splunk Enterprise
+  - Splunk Enterprise Security
+  - Splunk Cloud
+  required_fields:
+  - src_user
+  - object_category
+  - TargetUserName
+  - TargetSid
+  - dest
+  - result
+  - _time
+  risk_score: 100
+  security_domain: threat


### PR DESCRIPTION
Created new detection for CVE-2024-37085.

### Details

_What does this PR have in it? Screenshots are worth 1000 words 😄_

Brand new detection for newly released CVE related to VMWare and ransomware.

### Checklist

- [ ] Validate name matches `<platform>_<mitre att&ck technique>_<short description>` nomenclature
- [ ] [CI/CD](https://github.com/splunk/security_content/actions) jobs passed ✔️ 
- [ ] Validated SPL logic.
- [ ] Validated tags, description, and how to implement.
- [ ] Verified references match analytic.
- [ ] Confirm updates to lookups are handled properly.

### Notes For Submitters and Reviewers

- If you're submitting a PR from a fork, ensuring the box to allow updates from maintainers is checked will help speed up the process of getting it merged.
- Checking the output of the `build` CI job when it fails will likely show an error about what is failing. You may have a very descriptive error of the specific field(s) in the specific file(s) that is causing an issue. In some cases, its also possible there is an issue with the YAML. Many of these can be caught with the pre-commit hooks if you set them up. These errors will be less descriptive as to what exactly is wrong, but will give you a column and row position in a specific file where the YAML processing breaks. If you're having trouble with this, feel free to add a comment to your PR tagging one of the maintainers and we'll be happy to help troubleshoot it.
- Updates to existing lookup files can be tricky, because of how Splunk handles application updates and the differences between existing lookup files being updated vs new lookups. You can read more [here](https://docs.splunk.com/Documentation/SplunkCloud/8.2.2203/Admin/PrivateApps#Manage_lookups_in_Splunk_Cloud_Platform) but the short version is that any changes to lookup files need to bump the datestamp in the lookup CSV filename, and the reference to it in the YAML needs to be updated.